### PR TITLE
2 way dav sync support

### DIFF
--- a/calendar.php
+++ b/calendar.php
@@ -219,7 +219,7 @@ class calendar extends rcube_plugin
         
           foreach ($this->get_drivers() as $driver_name => $driver) {
               foreach ($preinstalled_calendars as $cal) {
-                  if ($driver_name == $cal['driver']) {    
+                  if ($driver_name == $cal['driver']) {   		  
                       if (!$driver->create_calendar($cal)) {
                           $error_msg = 'Unable to add default calendars' . ($driver && $driver->last_error ? ': ' . $driver->last_error :'');
                           $this->rc->output->show_message($error_msg, 'error');
@@ -441,6 +441,7 @@ class calendar extends rcube_plugin
       $this->load_drivers();
       foreach ($this->get_drivers() as $driver) {
         foreach ((array)$driver->list_calendars() as $id => $prop) {
+		
           $prop["driver"] = get_class($driver);
           $this->_cals[$id] = $prop;
           $this->_cal_driver_map[$id] = $driver;
@@ -1099,6 +1100,7 @@ if(count($cals) > 0){
         echo $this->ui->calendar_editform($action, $cal);
         exit;
       case "new":
+		// driver for creation of calendar
         $driver = $this->get_driver_by_gpc();
         $success = $driver->create_calendar($cal);
         $reload = true;
@@ -1110,8 +1112,9 @@ if(count($cals) > 0){
         break;
       case "delete":
         $driver = $this->get_driver_by_cal($cal['id']);
-        if ($success = $driver->delete_calendar($cal))
-          $this->rc->output->command('plugin.destroy_source', array('id' => $cal['id']));
+        if ($success = $driver->delete_calendar($cal)) {
+			$reload = true;
+		}
         break;
       case "subscribe":
         $driver = $this->get_driver_by_cal($cal['id']);

--- a/config.inc.php.dist
+++ b/config.inc.php.dist
@@ -40,7 +40,7 @@ $config['calendar_sync_period'] = "600";
 $config['calendar_default_calendar'] = 'Personal';
 
 // show a birthdays calendar from the user's address book(s)
-$config['calendar_contact_birthdays'] = false;	// TODO - DO NOT CHECK BOX IN RC SETTINGS - Instead, let NC generate the bday calendar and it will show up.
+$config['calendar_contact_birthdays'] = false;	// TODO
 
 
 // mapping of Roundcube date formats to calendar formats (long/short/agenda)
@@ -178,6 +178,7 @@ $config['kolab_invitation_calendars'] = false;
 // %u - Current webmail user name
 // %n - Calendar name
 // %i - Calendar UUID
+// %l - Current webmail user local part of name
 // $config['calendar_caldav_url'] = 'http://%h/iRony/calendars/%u/%i';
 
 // Driver to provide a resource directory ('ldap' is the only implementation yet).
@@ -228,13 +229,13 @@ $config['calendar_ical_debug'] = false;
 // Pre-installed calendars, added at first access to calendar section
 // Caldav driver is supported only
  $config['calendar_preinstalled_calendars'] = array(
-    'Nextcloud' => array(
-                    'driver'       		=> 'caldav',
-					'name'         		=> '',
-                    'caldav_user'  		=> '%u',
-                    'caldav_pass'  		=> '%p',
-					'caldav_auth_type'  => 'basic', // Authentication choices are 'basic' or 'digest'
-                    'caldav_url'   		=> 'https://%h/nextcloud/remote.php/dav/calendars/%u/',
-					'color' 	   		=>  '', // Can specify color using hex or leave blank for auto color
-                    'showAlarms'   		=> 1));
+    0 => array(
+                    'driver'       => 'caldav',
+                    'name'         => '',
+                    'caldav_user'  => '%l',
+                    'caldav_pass'  => '%p',
+                    'caldav_url'   => 'https://%h/remote.php/dav/calendars/%l/', //specify host URL instead of %h if nextcloud is on the other host
+                    'color' 	   =>  '',
+                    'showAlarms'   => 1));
+
 ?>

--- a/skins/elastic/elastic.css
+++ b/skins/elastic/elastic.css
@@ -3773,7 +3773,3 @@ html.touch #tasklist span.tags {
     overflow: hidden;
     text-overflow: ellipsis;
 }
-/*samoilov 29.10.2020 hide datepicker in left bottom corner*/
-#datepicker {
-	display:none;
-}

--- a/skins/elastic/elastic.css
+++ b/skins/elastic/elastic.css
@@ -3773,3 +3773,7 @@ html.touch #tasklist span.tags {
     overflow: hidden;
     text-overflow: ellipsis;
 }
+/*samoilov 29.10.2020 hide datepicker in left bottom corner*/
+#datepicker {
+	display:none;
+}

--- a/skins/elastic/override.css
+++ b/skins/elastic/override.css
@@ -1,0 +1,4 @@
+/* hide datepicker in left bottom corner, calendar selector in event editor, show url button in calendar options menu*/
+#datepicker, #calendar-select, #rcmbtn118  {
+	display:none;
+}

--- a/skins/elastic/templates/calendar.html
+++ b/skins/elastic/templates/calendar.html
@@ -1,6 +1,9 @@
 <roundcube:include file="includes/layout.html" />
 <roundcube:include file="includes/menu.html" />
 
+<!--add override.css -->
+<link rel="stylesheet" type="text/css" href="./plugins/calendar/skins/elastic/override.css">
+
 <h1 class="voice"><roundcube:label name="calendar.calendar" /></h1>
 
 <!-- calendars list -->


### PR DESCRIPTION
Hi. I've worked for some weeks on the update that will allow to sync RC and NC in almost 2 way. For now it supports the following actions:
1) Creation and editing calendars from RC (GUI) and NC (after RC sync)
2) Deletion  calendars only from RC (NC will get calendars from RC after sync if they were deleted)
3) Creation, deletion and editing events from RC (GUI) and NC (after RC sync). Warning! There is no support to move events from one calendar to another in RC (i've hidden this menu function) and NC (don't do it or you will get strange syncing behaviour). As a temporary workaround you can delete event and then rectreate it in another calendar.

There is no need to manually provide username and password for making any calendar actions.

**Make sure that you have php_curl installed on your system as my update uses it to do communications between RC and CalDAV on the NC server.**
This is only alpha so there might be some bugs =) So test it.
Also I will do some updates later.
Sorry for my bad coding cause this is only my hobby =)